### PR TITLE
Adding the cloud DNS API library and related methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Gemfile.local
 results.xml
 /vmpooler.yaml
 .idea
+*.json

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,16 +36,18 @@ Style/SwapValues: # (new in 1.1)
 #disabled
 
 Metrics/AbcSize:
-  Max: 77
+  Enabled: false
 Metrics/ClassLength:
-  Max: 430
+  Enabled: false
 Metrics/CyclomaticComplexity:
-  Max: 14
+  Enabled: false
 Metrics/MethodLength:
-  Max: 48
+  Enabled: false
 Metrics/PerceivedComplexity:
-  Max: 14
+  Enabled: false
 Metrics/ParameterLists:
-  Max: 6
+  Enabled: false
 Layout/LineLength:
-  Max: 220
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ GCE authorization is handled via a service account (or personal account) private
 
 1. GOOGLE_APPLICATION_CREDENTIALS environment variable eg GOOGLE_APPLICATION_CREDENTIALS=/my/home/directory/my_account_key.json
 
+### DNS
+DNS is integrated via Google's CloudDNS service. To enable a CloudDNS zone name must be provided in the config (see the example yaml file dns_zone_resource_name)
+
+An A record is then created in that zone upon instance creation with the VM's internal IP, and deleted when the instance is destroyed.
 
 ### Labels
 This provider adds labels to all resources that are managed
@@ -26,6 +30,13 @@ This provider adds labels to all resources that are managed
 
 Also see the usage of vmpooler's optional purge_unconfigured_resources, which is used to delete any resource found that
 do not have the pool label, and can be configured to allow a specific list of unconfigured pool names. 
+
+### Pre-requisite
+
+- A service account needs to be created and a private json key generated (see usage section)
+- The service account needs given permissions to the project (broad permissions would be compute v1 admin and dns admin). A yaml file is provided that lists the least-privilege permissions needed
+- if using DNS, a DNS zone needs to be created
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ GCE authorization is handled via a service account (or personal account) private
 1. GOOGLE_APPLICATION_CREDENTIALS environment variable eg GOOGLE_APPLICATION_CREDENTIALS=/my/home/directory/my_account_key.json
 
 ### DNS
-DNS is integrated via Google's CloudDNS service. To enable a CloudDNS zone name must be provided in the config (see the example yaml file dns_zone_resource_name)
+DNS is integrated via Google's CloudDNS service. To enable, a CloudDNS zone name must be provided in the config (see the example yaml file dns_zone_resource_name)
 
 An A record is then created in that zone upon instance creation with the VM's internal IP, and deleted when the instance is destroyed.
 
@@ -34,8 +34,8 @@ do not have the pool label, and can be configured to allow a specific list of un
 ### Pre-requisite
 
 - A service account needs to be created and a private json key generated (see usage section)
-- The service account needs given permissions to the project (broad permissions would be compute v1 admin and dns admin). A yaml file is provided that lists the least-privilege permissions needed
-- if using DNS, a DNS zone needs to be created
+- The service account needs to be given permissions to the project (broad permissions would be compute v1 admin and dns admin). A yaml file is provided that lists the least-privilege permissions needed
+- if using DNS, a DNS zone needs to be created in CloudDNS, and configured in the provider's config section with the name of that zone (dns_zone_resource_name). When not specified, the DNS setup and teardown is skipped.
 
 
 ## License

--- a/lib/vmpooler/providers/gce.rb
+++ b/lib/vmpooler/providers/gce.rb
@@ -198,7 +198,7 @@ module Vmpooler
             network_interfaces: [network_interfaces],
             labels: { 'vm' => new_vmname, 'pool' => pool_name, project => nil }
           )
-          # TODO: Maybe this will be needed to set the hostname (usually internal DNS name but in opur case for some reason its nil)
+          # TODO: Maybe this will be needed to set the hostname (usually internal DNS name but in our case for some reason its nil)
           # given_hostname = "#{new_vmname}.#{dns_zone}"
           # client.hostname = given_hostname if given_hostname
 

--- a/lib/vmpooler/providers/gce.rb
+++ b/lib/vmpooler/providers/gce.rb
@@ -86,8 +86,8 @@ module Vmpooler
           return provider_config['machine_type'] if provider_config['machine_type']
         end
 
-        def dns_zone
-          provider_config['dns_zone']
+        def domain
+          provider_config['domain']
         end
 
         def dns_zone_resource_name
@@ -459,7 +459,7 @@ module Vmpooler
         def vm_ready?(_pool_name, vm_name)
           begin
             # TODO: we could use a healthcheck resource attached to instance
-            open_socket(vm_name, dns_zone || global_config[:config]['domain'])
+            open_socket(vm_name, domain || global_config[:config]['domain'])
           rescue StandardError => _e
             return false
           end

--- a/lib/vmpooler/providers/gce.rb
+++ b/lib/vmpooler/providers/gce.rb
@@ -567,7 +567,7 @@ module Vmpooler
           rescue Google::Cloud::AlreadyExistsError => _e
             # DNS setup is done only for new instances, so in the rare case where a DNS record already exists (it is stale) and we replace it.
             # the error is Google::Cloud::AlreadyExistsError: alreadyExists: The resource 'entity.change.additions[0]' named 'instance-8.test.vmpooler.net. (A)' already exists
-            change =  dns_zone.replace(name, 'A', 60, [created_instance['ip']])
+            change = dns_zone.replace(name, 'A', 60, [created_instance['ip']])
             debug_logger("#{change.id} - #{change.started_at} - #{change.status} DNS address previously existed and was replaced") if change
           end
         end

--- a/scripts/GCE_custom_role_for_SA.yaml
+++ b/scripts/GCE_custom_role_for_SA.yaml
@@ -1,0 +1,38 @@
+title: Custom vmpooler provider
+description: for the vmpooler provider
+stage: GA
+includedPermissions:
+- compute.disks.create
+- compute.disks.createSnapshot
+- compute.disks.delete
+- compute.disks.get
+- compute.disks.list
+- compute.disks.setLabels
+- compute.disks.use
+- compute.instances.attachDisk
+- compute.instances.create
+- compute.instances.delete
+- compute.instances.detachDisk
+- compute.instances.get
+- compute.instances.list
+- compute.instances.setLabels
+- compute.instances.start
+- compute.instances.stop
+- compute.snapshots.create
+- compute.snapshots.delete
+- compute.snapshots.get
+- compute.snapshots.list
+- compute.snapshots.setLabels
+- compute.snapshots.useReadOnly
+- compute.subnetworks.use
+- compute.zoneOperations.get
+- dns.changes.create
+- dns.changes.get
+- dns.changes.list
+- dns.managedZones.get
+- dns.managedZones.list
+- dns.resourceRecordSets.create
+- dns.resourceRecordSets.update
+- dns.resourceRecordSets.delete
+- dns.resourceRecordSets.get
+- dns.resourceRecordSets.list

--- a/scripts/GCE_custom_role_for_SA.yaml
+++ b/scripts/GCE_custom_role_for_SA.yaml
@@ -16,6 +16,7 @@ includedPermissions:
 - compute.instances.get
 - compute.instances.list
 - compute.instances.setLabels
+- compute.instances.setTags
 - compute.instances.start
 - compute.instances.stop
 - compute.snapshots.create

--- a/scripts/create_custom_role
+++ b/scripts/create_custom_role
@@ -1,0 +1,5 @@
+#!/bin/bash
+#set your project name in GCE here
+project_id="vmpooler-test"
+#this creates a custom role, that should then be applied to a service account used to run the API requests.
+gcloud iam roles create Customvmpoolerprovider --project=$project-id --file=GCE_custom_role_for_SA.yaml

--- a/spec/dnsservice_helper.rb
+++ b/spec/dnsservice_helper.rb
@@ -1,0 +1,9 @@
+MockDNS = Struct.new(
+  # https://rubydoc.info/gems/google-cloud-dns/0.35.1/Google/Cloud/Dns
+  :change, :credentials, :project, :record, :zone,
+  keyword_init: true
+) do
+  def zone(zone)
+    self.zone = zone
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,18 @@
 # frozen_string_literal: true
 
 require 'simplecov'
+=begin
 SimpleCov.start do
   add_filter '/spec/'
 end
+=end
 require 'helpers'
 require 'rspec'
 require 'vmpooler'
 require 'redis'
 require 'vmpooler/metrics'
 require 'computeservice_helper'
+require 'dnsservice_helper'
 
 def project_root_dir
   File.dirname(File.dirname(__FILE__))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-=begin
 SimpleCov.start do
   add_filter '/spec/'
 end
-=end
 require 'helpers'
 require 'rspec'
 require 'vmpooler'

--- a/spec/unit/providers/gce_spec.rb
+++ b/spec/unit/providers/gce_spec.rb
@@ -26,8 +26,6 @@ describe 'Vmpooler::PoolManager::Provider::Gce' do
     zone: '#{zone}'
     network_name: global/networks/default
     # network_name: 'projects/itsysopsnetworking/global/networks/shared1'
-    dns_zone_resource_name: 'example-com'
-    dns_zone: 'example.com'
 :pools:
   - name: '#{poolname}'
     alias: [ 'mockpool' ]
@@ -55,6 +53,8 @@ EOT
   end
 
   subject { Vmpooler::PoolManager::Provider::Gce.new(config, logger, metrics, redis_connection_pool, 'gce', provider_options) }
+
+  before(:each) { allow(subject).to receive(:dns).and_return(MockDNS.new()) }
 
   describe '#name' do
     it 'should be gce' do
@@ -89,7 +89,7 @@ EOT
     end
 
     context 'in itsysops' do
-      let(:vmname) { "instance-10" }
+      let(:vmname) { "instance-15" }
       let(:project) { 'vmpooler-test' }
       let(:config) { YAML.load(<<-EOT
 ---

--- a/spec/unit/providers/gce_spec.rb
+++ b/spec/unit/providers/gce_spec.rb
@@ -75,7 +75,7 @@ EOT
     zone: '#{zone}'
     network_name: 'projects/itsysopsnetworking/global/networks/shared1'
     dns_zone_resource_name: 'test-vmpooler-puppet-net'
-    dns_zone: 'test.vmpooler.puppet.net'
+    domain: 'test.vmpooler.puppet.net'
 :pools:
   - name: '#{poolname}'
     alias: [ 'mockpool' ]

--- a/spec/unit/providers/gce_spec.rb
+++ b/spec/unit/providers/gce_spec.rb
@@ -11,8 +11,7 @@ describe 'Vmpooler::PoolManager::Provider::Gce' do
   let(:metrics) { Vmpooler::Metrics::DummyStatsd.new }
   let(:poolname) { 'debian-9' }
   let(:provider_options) { { 'param' => 'value' } }
-  # let(:project) { 'vmpooler-test' }
-  let(:project) { 'dio-samuel-dev' }
+  let(:project) { 'vmpooler-test' }
   let(:zone) { 'us-west1-b' }
   let(:config) { YAML.load(<<-EOT
 ---
@@ -25,7 +24,6 @@ describe 'Vmpooler::PoolManager::Provider::Gce' do
     project: '#{project}'
     zone: '#{zone}'
     network_name: global/networks/default
-    # network_name: 'projects/itsysopsnetworking/global/networks/shared1'
 :pools:
   - name: '#{poolname}'
     alias: [ 'mockpool' ]
@@ -34,7 +32,6 @@ describe 'Vmpooler::PoolManager::Provider::Gce' do
     timeout: 10
     ready_ttl: 1440
     provider: 'gce'
-    # subnetwork_name: 'projects/itsysopsnetworking/regions/us-west1/subnetworks/vmpooler-test'
     machine_type: 'zones/#{zone}/machineTypes/e2-micro'
 EOT
     )
@@ -63,31 +60,6 @@ EOT
   end
 
   describe '#manual tests live' do
-    skip 'runs in gce' do
-      puts 'creating'
-      result = subject.create_vm(poolname, vmname)
-      subject.get_vm(poolname, vmname)
-      subject.vms_in_pool(poolname)
-
-      puts 'create snapshot w/ one disk'
-      result = subject.create_snapshot(poolname, vmname, 'sams')
-      puts 'create disk'
-      result = subject.create_disk(poolname, vmname, 10)
-      puts 'create snapshot w/ 2 disks'
-      result = subject.create_snapshot(poolname, vmname, 'sams2')
-      puts 'revert snapshot'
-      result = subject.revert_snapshot(poolname, vmname, 'sams')
-      result = subject.destroy_vm(poolname, vmname)
-    end
-
-    skip 'runs existing' do
-      # result = subject.create_snapshot(poolname, vmname, "sams")
-      # result = subject.revert_snapshot(poolname, vmname, "sams")
-      # puts subject.get_vm(poolname, vmname)
-      result = subject.create_vm(poolname, vmname)
-      result = subject.destroy_vm(poolname, vmname)
-    end
-
     context 'in itsysops' do
       let(:vmname) { "instance-15" }
       let(:project) { 'vmpooler-test' }

--- a/spec/unit/providers/gce_spec.rb
+++ b/spec/unit/providers/gce_spec.rb
@@ -13,26 +13,26 @@ describe 'Vmpooler::PoolManager::Provider::Gce' do
   let(:provider_options) { { 'param' => 'value' } }
   let(:project) { 'vmpooler-test' }
   let(:zone) { 'us-west1-b' }
-  let(:config) { YAML.load(<<-EOT
----
-:config:
-  max_tries: 3
-  retry_factor: 10
-:providers:
-  :gce:
-    connection_pool_timeout: 1
-    project: '#{project}'
-    zone: '#{zone}'
-    network_name: global/networks/default
-:pools:
-  - name: '#{poolname}'
-    alias: [ 'mockpool' ]
-    template: 'projects/debian-cloud/global/images/family/debian-9'
-    size: 5
-    timeout: 10
-    ready_ttl: 1440
-    provider: 'gce'
-    machine_type: 'zones/#{zone}/machineTypes/e2-micro'
+  let(:config) { YAML.load(<<~EOT
+  ---
+  :config:
+    max_tries: 3
+    retry_factor: 10
+  :providers:
+    :gce:
+      connection_pool_timeout: 1
+      project: '#{project}'
+      zone: '#{zone}'
+      network_name: global/networks/default
+  :pools:
+    - name: '#{poolname}'
+      alias: [ 'mockpool' ]
+      template: 'projects/debian-cloud/global/images/family/debian-9'
+      size: 5
+      timeout: 10
+      ready_ttl: 1440
+      provider: 'gce'
+      machine_type: 'zones/#{zone}/machineTypes/e2-micro'
 EOT
     )
   }
@@ -61,36 +61,38 @@ EOT
 
   describe '#manual tests live' do
     context 'in itsysops' do
-      let(:vmname) { "instance-15" }
+      before(:each) { allow(subject).to receive(:dns).and_call_original }
+      let(:vmname) { "instance-24" }
       let(:project) { 'vmpooler-test' }
-      let(:config) { YAML.load(<<-EOT
----
-:config:
-  max_tries: 3
-  retry_factor: 10
-:providers:
-  :gce:
-    connection_pool_timeout: 1
-    project: '#{project}'
-    zone: '#{zone}'
-    network_name: 'projects/itsysopsnetworking/global/networks/shared1'
-    dns_zone_resource_name: 'test-vmpooler-puppet-net'
-    domain: 'test.vmpooler.puppet.net'
-:pools:
-  - name: '#{poolname}'
-    alias: [ 'mockpool' ]
-    template: 'projects/debian-cloud/global/images/family/debian-9'
-    size: 5
-    timeout: 10
-    ready_ttl: 1440
-    provider: 'gce'
-    subnetwork_name: 'projects/itsysopsnetworking/regions/us-west1/subnetworks/vmpooler-test'
-    machine_type: 'zones/#{zone}/machineTypes/e2-micro'
-      EOT
+      let(:config) { YAML.load(<<~EOT
+      ---
+      :config:
+        max_tries: 3
+        retry_factor: 10
+      :providers:
+        :gce:
+          connection_pool_timeout: 1
+          project: '#{project}'
+          zone: '#{zone}'
+          network_name: 'projects/itsysopsnetworking/global/networks/shared1'
+          dns_zone_resource_name: 'test-vmpooler-puppet-net'
+          domain: 'test.vmpooler.puppet.net'
+      :pools:
+        - name: '#{poolname}'
+          alias: [ 'mockpool' ]
+          template: 'projects/debian-cloud/global/images/family/debian-9'
+          size: 5
+          timeout: 10
+          ready_ttl: 1440
+          provider: 'gce'
+          subnetwork_name: 'projects/itsysopsnetworking/regions/us-west1/subnetworks/vmpooler-test'
+          machine_type: 'zones/#{zone}/machineTypes/e2-micro'
+EOT
       ) }
       skip 'gets a vm' do
         result = subject.create_vm(poolname, vmname)
-        #subject.get_vm(poolname, vmname)
+        #result = subject.destroy_vm(poolname, vmname)
+        subject.get_vm(poolname, vmname)
         #subject.dns_teardown({'name' => vmname})
         # subject.dns_setup({'name' => vmname, 'ip' => '1.2.3.5'})
       end

--- a/spec/vmpooler-provider-gce/vmpooler_provider_gce_spec.rb
+++ b/spec/vmpooler-provider-gce/vmpooler_provider_gce_spec.rb
@@ -1,0 +1,9 @@
+require 'rspec'
+
+describe 'VmpoolerProviderGce' do
+  context 'when creating class ' do
+    it 'sets a version' do
+      expect(VmpoolerProviderGce::VERSION).not_to be_nil
+    end
+  end
+end

--- a/vmpooler-provider-gce.gemspec
+++ b/vmpooler-provider-gce.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_dependency "google-apis-compute_v1", "~> 0.14"
   s.add_dependency "googleauth", "~> 0.16.2"
+  s.add_dependency "google-cloud-dns", "~>0.35.1"
   
   s.add_development_dependency 'vmpooler', '~> 1.3', '>= 1.3.0'
 

--- a/vmpooler-provider-gce.gemspec
+++ b/vmpooler-provider-gce.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_dependency "google-apis-compute_v1", "~> 0.14"
   s.add_dependency "googleauth", "~> 0.16.2"
-  s.add_dependency "google-cloud-dns", "~>0.35.1"
+  s.add_dependency "google-cloud-dns", "~> 0.35.1"
   
   s.add_development_dependency 'vmpooler', '~> 1.3', '>= 1.3.0'
 

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -72,6 +72,13 @@
 #   - network_name
 #     The GCE network_name to use
 #     (required)
+#   - dns_zone_resource_name
+#     The name given to the DNS zone ressource. This is not the domain, but the name identifier of a zone eg example-com
+#     (optional) when not set, the dns setup / teardown is skipped
+#   - dns_zone
+#     The dns zone domain set for the dns_zone_resource_name. This becomes the domain part of the FQDN ie $vm_name.$dns_zone
+#     When setting multiple providers at the same time, this value should be set for each GCE pools.
+#     default to: global config:domain. if dns_zone is set, it overwrites the top-level domain when checking vm_ready?
 # Example:
 
   :gce:

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -75,10 +75,11 @@
 #   - dns_zone_resource_name
 #     The name given to the DNS zone ressource. This is not the domain, but the name identifier of a zone eg example-com
 #     (optional) when not set, the dns setup / teardown is skipped
-#   - dns_zone
-#     The dns zone domain set for the dns_zone_resource_name. This becomes the domain part of the FQDN ie $vm_name.$dns_zone
+#   - domain
+#     Overwrites the global domain parameter. This should match the dns zone domain set for the dns_zone_resource_name.
+#     It is used to infer the domain part of the FQDN ie $vm_name.$domain
 #     When setting multiple providers at the same time, this value should be set for each GCE pools.
-#     default to: global config:domain. if dns_zone is set, it overwrites the top-level domain when checking vm_ready?
+#     (optional) If not explicitely set, the FQDN is inferred using the global 'domain' config parameter
 # Example:
 
   :gce:
@@ -86,6 +87,8 @@
     zone: 'us-central1-f'
     machine_type: ''
     network_name: ''
+    dns_zone_resource_name: 'subdomain-example-com'
+    domain: 'subdomain.example.com'
 
 # :pools:
 #


### PR DESCRIPTION
we setup DNS when a VM is created and tear it down when a VM is deleted
the DNS zone should exist already and is referenced by a provider setting
the dns zone is also set in order to use it for vm_ready? instead of the global
domain
instances have a label that identifies which project they belong to, so
it can be used for FW rules