### PR TITLE
Set hostname for instance during create_vm

### DIFF
--- a/lib/vmpooler/providers/gce.rb
+++ b/lib/vmpooler/providers/gce.rb
@@ -191,9 +191,13 @@ module Vmpooler
             boot: true,
             initialize_params: Google::Apis::ComputeV1::AttachedDiskInitializeParams.new(init_params)
           )
+          append_domain = domain || global_config[:config]['domain']
+          fqdn = "#{new_vmname}.#{append_domain}" if append_domain
+
           # Assume all pool config is valid i.e. not missing
           client = ::Google::Apis::ComputeV1::Instance.new(
             name: new_vmname,
+            hostname: fqdn,
             machine_type: pool['machine_type'],
             disks: [disk],
             network_interfaces: [network_interfaces],


### PR DESCRIPTION
This sets the instance hostname to the configured domain according to https://cloud.google.com/compute/docs/instances/custom-hostname-vm#api and https://googleapis.dev/ruby/google-api-client/latest/Google/Apis/ComputeV1/Instance.html#hostname-instance_method