### PR TITLE
(DIO-3162) vmpooler gce provider to support disk type (to use ssd)

### DIFF
--- a/lib/vmpooler/providers/gce.rb
+++ b/lib/vmpooler/providers/gce.rb
@@ -181,15 +181,18 @@ module Vmpooler
             network: network_name
           )
           network_interfaces.subnetwork = subnetwork_name(pool_name) if subnetwork_name(pool_name)
-          init_params = {
+          init_params = Google::Apis::ComputeV1::AttachedDiskInitializeParams.new(
             source_image: pool['template'], # The source image to create this disk.
             labels: { 'vm' => new_vmname, 'pool' => pool_name },
             disk_name: "#{new_vmname}-disk0"
-          }
+          )
+          if pool['disk_type'] && !pool['disk_type'].empty?
+            init_params.disk_type = "https://www.googleapis.com/compute/v1/projects/#{project}/zones/#{zone(pool_name)}/diskTypes/#{pool['disk_type']}"
+          end
           disk = Google::Apis::ComputeV1::AttachedDisk.new(
             auto_delete: true,
             boot: true,
-            initialize_params: Google::Apis::ComputeV1::AttachedDiskInitializeParams.new(init_params)
+            initialize_params: init_params
           )
           append_domain = domain || global_config[:config]['domain']
           fqdn = "#{new_vmname}.#{append_domain}" if append_domain

--- a/lib/vmpooler/providers/gce.rb
+++ b/lib/vmpooler/providers/gce.rb
@@ -186,9 +186,11 @@ module Vmpooler
             labels: { 'vm' => new_vmname, 'pool' => pool_name },
             disk_name: "#{new_vmname}-disk0"
           )
+          # rubocop:disable Style/IfUnlessModifier
           if pool['disk_type'] && !pool['disk_type'].empty?
             init_params.disk_type = "https://www.googleapis.com/compute/v1/projects/#{project}/zones/#{zone(pool_name)}/diskTypes/#{pool['disk_type']}"
           end
+          # rubocop:enable Style/IfUnlessModifier
           disk = Google::Apis::ComputeV1::AttachedDisk.new(
             auto_delete: true,
             boot: true,

--- a/spec/unit/providers/gce_spec.rb
+++ b/spec/unit/providers/gce_spec.rb
@@ -62,7 +62,7 @@ EOT
   describe '#manual tests live' do
     context 'in itsysops' do
       before(:each) { allow(subject).to receive(:dns).and_call_original }
-      let(:vmname) { "instance-24" }
+      let(:vmname) { "instance-27" }
       let(:project) { 'vmpooler-test' }
       let(:config) { YAML.load(<<~EOT
       ---
@@ -87,6 +87,7 @@ EOT
           provider: 'gce'
           subnetwork_name: 'projects/itsysopsnetworking/regions/us-west1/subnetworks/vmpooler-test'
           machine_type: 'zones/#{zone}/machineTypes/e2-micro'
+          disk_type: 'pd-ssd'
 EOT
       ) }
       skip 'gets a vm' do

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -146,6 +146,10 @@
 #       (optional: default is global provider zone value)
 #     - machine_type
 #       Full or partial URL of the machine type resource to use for this instance, in the format: zones/zone/machineTypes/machine-type
+#     - disk_type
+#       the disk type to use, see https://cloud.google.com/compute/docs/disks one of
+#         pd-standard, pd-balanced, pd-ssd or pd-extreme
+#       (optional, when nil or empty defaults to pd-standard)
 # Example:
 
 :pools:


### PR DESCRIPTION
Added a new pool config named disk_type, which can be set to pd-ssd to
use a SSD disk attahed to the instance. When not set, or set to empty,
the google default of pd-standard is used